### PR TITLE
Support for Safari browser

### DIFF
--- a/src/osk-detector.js
+++ b/src/osk-detector.js
@@ -22,7 +22,7 @@ const
 	isIOS = isIPad || isIPhone,
 
 	getScreenOrientationType = () =>
-		screen.orientation.type.startsWith('portrait') ? 'portrait' : 'landscape',
+		screen.orientation && screen.orientation.type.startsWith('portrait') ? 'portrait' : 'landscape',
 	
 	// rejectCapture :: Stream Boolean -> Stream a -> Stream a
 	rejectCapture = curry(compose(join, snapshot((valveValue, event) => valveValue ? empty() : now(event)))),

--- a/src/osk-detector.js
+++ b/src/osk-detector.js
@@ -19,10 +19,11 @@ const
    isIPhone = /\b(\w*iPhone\w*)\b/.test(userAgent) &&
             /\b(\w*Mobile\w*)\b/.test(userAgent) &&
             isTouchable,
-	isIOS = isIPad || isIPhone,
+  isIOS = isIPad || isIPhone,
+  orientation = (screen.orientation || {}).type || screen.mozOrientation || screen.msOrientation,
 
 	getScreenOrientationType = () =>
-		screen.orientation && screen.orientation.type.startsWith('portrait') ? 'portrait' : 'landscape',
+		orientation && orientation.startsWith('portrait') ? 'portrait' : 'landscape',
 	
 	// rejectCapture :: Stream Boolean -> Stream a -> Stream a
 	rejectCapture = curry(compose(join, snapshot((valveValue, event) => valveValue ? empty() : now(event)))),
@@ -186,5 +187,6 @@ function initWithCallback(userCallback) {
 
 export {
 	initWithCallback as subscribe,
-	isSupported
+  isSupported,
+  orientation,
 };


### PR DESCRIPTION
Since Safari doesn't support the `ScreenOrientation` API [(reference)](https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation), this causes a crash when trying to get the screen orientation type. I don't know if it is correct to fallback to `landscape`, but atleast is a start.

Edit: thanks for the amazing work @semmel, this is an awesome learn resource for FP.
